### PR TITLE
Fix Annex A example

### DIFF
--- a/doc/main.html
+++ b/doc/main.html
@@ -309,7 +309,7 @@ STABLEREV = 4(DIGIT) [2(DIGIT)]
 
 <pre>
 {
-  "$schema": "https://json-schema.org/draft/2020-12/meta/core",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://smpte-ra.org/json-schema/2199-1/2022/foo",
   "$comment": "See SMPTE AG 30 (https://www.smpte.org/about/policies-and-governance) for copyright and license information.",
   "title": "foo",

--- a/doc/main.html
+++ b/doc/main.html
@@ -310,7 +310,7 @@ STABLEREV = 4(DIGIT) [2(DIGIT)]
 <pre>
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://smpte-ra.org/json-schema/2199-1/2022/foo",
+  "$id": "https://www.smpte-ra.org/json-schema/2199-1/2022/foo",
   "$comment": "See SMPTE AG 30 (https://www.smpte.org/about/policies-and-governance) for copyright and license information.",
   "title": "foo",
   "type": "object",


### PR DESCRIPTION
Make the $schema value equal to what would typically be used per:
* https://json-schema.org/understanding-json-schema/basics#declaring-a-json-schema
* All the examples in https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-00

$id must comply with AG 25!